### PR TITLE
Changes to embedded(command) posts

### DIFF
--- a/DiscordBotLib/8BallModule.cs
+++ b/DiscordBotLib/8BallModule.cs
@@ -61,7 +61,9 @@ namespace DiscordBotLib
             content.Append("\n"); // New line
             content.Append($"Answer: **{prediction}**");
 
-            await CreateEmbed(
+            Helper LocalHelper = new Helper();
+            await LocalHelper.CreateEmbed(
+                Context,
                 ":8ball:",
                 "8Ball prdiction:",
                 content.ToString());

--- a/DiscordBotLib/8BallModule.cs
+++ b/DiscordBotLib/8BallModule.cs
@@ -66,7 +66,8 @@ namespace DiscordBotLib
                 Context,
                 ":8ball:",
                 "8Ball prdiction:",
-                content.ToString());
+                content.ToString(),
+                true);
         }
     }
 }

--- a/DiscordBotLib/8BallModule.cs
+++ b/DiscordBotLib/8BallModule.cs
@@ -61,8 +61,7 @@ namespace DiscordBotLib
             content.Append("\n"); // New line
             content.Append($"Answer: **{prediction}**");
 
-            Helper LocalHelper = new Helper();
-            await LocalHelper.CreateEmbed(
+            await Helper.CreateEmbed(
                 Context,
                 ":8ball:",
                 "8Ball prdiction:",

--- a/DiscordBotLib/8BallModule.cs
+++ b/DiscordBotLib/8BallModule.cs
@@ -41,7 +41,9 @@ namespace DiscordBotLib
 
             // Initialize strings
             string prediction = string.Empty;
-            string title = string.Empty;
+            string emoji = ":8ball:";
+            string title = "8Ball prdiction:";
+            string body = null;
 
             // additional logic, so that the 8Ball prediction doesn't repeat
             while (true) {
@@ -55,18 +57,12 @@ namespace DiscordBotLib
             previousPrediction = prediction;
 
             // question && answer
-            StringBuilder content = new StringBuilder();
+            body = $"Question: _{Context.Message.Content.Replace(".8ball ", null)}_";
+            body += "\n"; // New line
+            body += $"Answer: **{prediction}**";
 
-            content.Append($"Question: _{Context.Message.Content.Replace(".8ball ", null)}_");
-            content.Append("\n"); // New line
-            content.Append($"Answer: **{prediction}**");
-
-            await Helper.CreateEmbed(
-                Context,
-                ":8ball:",
-                "8Ball prdiction:",
-                content.ToString(),
-                true);
+            // Send response
+            await Helper.CreateEmbed(Context, emoji, title, body, null, true);
         }
     }
 }

--- a/DiscordBotLib/8BallModule.cs
+++ b/DiscordBotLib/8BallModule.cs
@@ -8,6 +8,7 @@ using Discord;
 using Discord.Commands;
 using System;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace DiscordBotLib
@@ -38,10 +39,9 @@ namespace DiscordBotLib
                 "No","No Doubt About It","Positively","Prospect Good","So It Shall Be","The Stars Say No",
                 "Unlikely","Very Likely","Yes","You Can Count On It" };
 
-            var embed = new EmbedBuilder();
-            embed.WithTitle(":8ball:");
-            embed.WithColor(Helper.GetRandomColor());
+            // Initialize strings
             string prediction = string.Empty;
+            string title = string.Empty;
 
             // additional logic, so that the 8Ball prediction doesn't repeat
             while (true) {
@@ -51,16 +51,20 @@ namespace DiscordBotLib
                     break;
             }
 
-            // mention users if any
-            string mentionedUsers = base.MentionedUsers();
-
             // update previous prediction
             previousPrediction = prediction;
-            if ( string.Empty == mentionedUsers)
-                embed.AddField("8Ball Prediction:", prediction);
-            else
-                embed.AddField("8Ball Prediction:", mentionedUsers + prediction);
-            await ReplyAsync(string.Empty, false, embed);
+
+            // question && answer
+            StringBuilder content = new StringBuilder();
+
+            content.Append($"Question: _{Context.Message.Content.Replace(".8ball ", null)}_");
+            content.Append("\n"); // New line
+            content.Append($"Answer: **{prediction}**");
+
+            await CreateEmbed(
+                ":8ball:",
+                "8Ball prdiction:",
+                content.ToString());
         }
     }
 }

--- a/DiscordBotLib/AboutModule.cs
+++ b/DiscordBotLib/AboutModule.cs
@@ -10,6 +10,7 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using Discord;
+using System.Collections.Generic;
 
 namespace DiscordBotLib
 {
@@ -31,27 +32,25 @@ namespace DiscordBotLib
         }
 
         private async Task AboutCommand() {
-            var embed = new EmbedBuilder();
-            embed.WithTitle("Hello! This is @HassBot, written by @skalavala \n");
-            embed.WithColor(Helper.GetRandomColor());
-            embed.AddInlineField("Up Since", $"{ GetUptime() }");
-            embed.AddInlineField("Total Users", $"{Context.Client.Guilds.Sum(g => g.Users.Count)}");
-            embed.AddInlineField("Heap Size", $"{GetHeapSize()} MiB");
-            embed.AddInlineField("Memory", $"{ GetMemoryUsage() }");
-            embed.AddInlineField("Discord Lib Version", $"{ GetLibrary() }");
-            embed.AddInlineField("Latency", $" { GetLatency() }");
-            embed.AddField("GitHub", "You can find the source code here https://github.com/skalavala/HassBot");
-            embed.WithFooter(footer => footer.Text = string.Format(
-                Constants.INVOKED_BY, Context.User.Username));
-            embed.WithCurrentTimestamp();
+            var inline = new List<Tuple<string, string>>();
+            string emoji = ":wave:";
+            string title = "Hello! This is @HassBot, written by @skalavala";
+            string body = "You can find the source code here https://github.com/skalavala/HassBot";
+
+            inline.Add(new Tuple<string, string>("Up Since", $"{ GetUptime() }"));
+            inline.Add(new Tuple<string, string>("Total Users", $"{Context.Client.Guilds.Sum(g => g.Users.Count)}"));
+            inline.Add(new Tuple<string, string>("Heap Size", $"{GetHeapSize()} MiB"));
+            inline.Add(new Tuple<string, string>("Memory", $"{ GetMemoryUsage() }"));
+            inline.Add(new Tuple<string, string>("Discord Lib Version", $"{ GetLibrary() }"));
+            inline.Add(new Tuple<string, string>("Latency", $" { GetLatency() }"));
 
             // mention users if any
             string mentionedUsers = base.MentionedUsers();
             if (string.Empty != mentionedUsers)
-                embed.AddInlineField("FYI", mentionedUsers);
+                body = string.Format("FYI {0} \n", mentionedUsers) + body;
 
-            await Helper.DeleteMessage(Context, true);
-            await ReplyAsync(string.Empty, false, embed);
+            // Send response
+            await Helper.CreateEmbed(Context, emoji, title, body, inline, true);
         }
 
         public string GetUptime() {

--- a/DiscordBotLib/AboutModule.cs
+++ b/DiscordBotLib/AboutModule.cs
@@ -50,7 +50,8 @@ namespace DiscordBotLib
             if (string.Empty != mentionedUsers)
                 embed.AddInlineField("FYI", mentionedUsers);
 
-            await DeleteMessage();
+            Helper LocalHelper = new Helper();
+            await LocalHelper.DeleteMessage(Context);
             await ReplyAsync(string.Empty, false, embed);
         }
 

--- a/DiscordBotLib/AboutModule.cs
+++ b/DiscordBotLib/AboutModule.cs
@@ -51,7 +51,7 @@ namespace DiscordBotLib
                 embed.AddInlineField("FYI", mentionedUsers);
 
             Helper LocalHelper = new Helper();
-            await LocalHelper.DeleteMessage(Context);
+            await LocalHelper.DeleteMessage(Context, true);
             await ReplyAsync(string.Empty, false, embed);
         }
 

--- a/DiscordBotLib/AboutModule.cs
+++ b/DiscordBotLib/AboutModule.cs
@@ -41,12 +41,16 @@ namespace DiscordBotLib
             embed.AddInlineField("Discord Lib Version", $"{ GetLibrary() }");
             embed.AddInlineField("Latency", $" { GetLatency() }");
             embed.AddField("GitHub", "You can find the source code here https://github.com/skalavala/HassBot");
+            embed.WithFooter(footer => footer.Text = string.Format(
+                Constants.INVOKED_BY, Context.User.Username));
+            embed.WithCurrentTimestamp();
 
             // mention users if any
             string mentionedUsers = base.MentionedUsers();
             if (string.Empty != mentionedUsers)
-                embed.AddInlineField("FYI", mentionedUsers);            
+                embed.AddInlineField("FYI", mentionedUsers);
 
+            await DeleteMessage();
             await ReplyAsync(string.Empty, false, embed);
         }
 

--- a/DiscordBotLib/AboutModule.cs
+++ b/DiscordBotLib/AboutModule.cs
@@ -50,8 +50,7 @@ namespace DiscordBotLib
             if (string.Empty != mentionedUsers)
                 embed.AddInlineField("FYI", mentionedUsers);
 
-            Helper LocalHelper = new Helper();
-            await LocalHelper.DeleteMessage(Context, true);
+            await Helper.DeleteMessage(Context, true);
             await ReplyAsync(string.Empty, false, embed);
         }
 

--- a/DiscordBotLib/BaseModule.cs
+++ b/DiscordBotLib/BaseModule.cs
@@ -33,8 +33,7 @@ namespace DiscordBotLib
 
         protected async Task DisplayUsage(string usageString)
         {
-            Helper LocalHelper = new Helper();
-            await LocalHelper.CreateEmbed(
+            await Helper.CreateEmbed(
                 Context,
                 Constants.EMOJI_INFORMATION,
                 Constants.USAGE_TITLE,

--- a/DiscordBotLib/BaseModule.cs
+++ b/DiscordBotLib/BaseModule.cs
@@ -42,7 +42,7 @@ namespace DiscordBotLib
 
         private static readonly log4net.ILog logger =
              log4net.LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        public async Task DeleteMessage()
+        private async Task DeleteMessage()
         {
             logger.Debug("Deleting command message " +
                 Context.Message + " from " + Context.User.Username + " in " + Context.Channel.Name);
@@ -55,10 +55,7 @@ namespace DiscordBotLib
             string content = null,
             bool removeoriginalmessage = true)
         {
-            if (removeoriginalmessage)
-            {
-                await DeleteMessage();
-            }
+
             var embed = new EmbedBuilder();
 
             // Add a random color to the embedded post
@@ -86,6 +83,13 @@ namespace DiscordBotLib
             // Add timestamp
             embed.WithCurrentTimestamp();
 
+            // Remove original if needed
+            if (removeoriginalmessage)
+            {
+                await DeleteMessage();
+            }
+
+            // Send message
             await ReplyAsync(string.Empty, false, embed);
         }
     }

--- a/DiscordBotLib/BaseModule.cs
+++ b/DiscordBotLib/BaseModule.cs
@@ -42,7 +42,7 @@ namespace DiscordBotLib
 
         private static readonly log4net.ILog logger =
              log4net.LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        private async Task DeleteMessage()
+        public async Task DeleteMessage()
         {
             logger.Debug("Deleting command message " +
                 Context.Message + " from " + Context.User.Username + " in " + Context.Channel.Name);

--- a/DiscordBotLib/BaseModule.cs
+++ b/DiscordBotLib/BaseModule.cs
@@ -1,11 +1,7 @@
 ﻿using Discord;
 using Discord.Commands;
-using Discord.WebSocket;
-using HassBotUtils;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace DiscordBotLib
@@ -37,10 +33,59 @@ namespace DiscordBotLib
 
         protected async Task DisplayUsage(string usageString)
         {
+            await CreateEmbed(
+                Constants.EMOJI_INFORMATION,
+                Constants.USAGE_TITLE,
+                usageString
+                );
+        }
+
+        private static readonly log4net.ILog logger =
+             log4net.LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+        public async Task DeleteMessage()
+        {
+            logger.Debug("Deleting command message " +
+                Context.Message + " from " + Context.User.Username + " in " + Context.Channel.Name);
+            await Context.Message.DeleteAsync();
+        }
+
+        public async Task CreateEmbed(
+            string emoji = null,
+            string title = null,
+            string content = null,
+            bool removeoriginalmessage = true)
+        {
+            if (removeoriginalmessage)
+            {
+                await DeleteMessage();
+            }
             var embed = new EmbedBuilder();
-            embed.WithTitle(Constants.EMOJI_INFORMATION);
-            embed.WithColor(Color.DarkRed);
-            embed.AddInlineField(Constants.USAGE_TITLE, usageString);
+
+            // Add a random color to the embedded post
+            embed.WithColor(Helper.GetRandomColor());
+
+            // Add Title
+            // Add emoji if any
+            if (emoji != null || emoji != String.Empty)
+            {
+                embed.WithTitle(emoji + " " + title);
+            }
+            else
+            {
+                embed.WithTitle(title);
+            }
+
+            // Add content
+            embed.WithDescription(content);
+
+            // Footer
+            // Add invoker
+            embed.WithFooter(footer => footer.Text = string.Format(
+                Constants.INVOKED_BY, Context.User.Username));
+
+            // Add timestamp
+            embed.WithCurrentTimestamp();
+
             await ReplyAsync(string.Empty, false, embed);
         }
     }

--- a/DiscordBotLib/BaseModule.cs
+++ b/DiscordBotLib/BaseModule.cs
@@ -33,64 +33,13 @@ namespace DiscordBotLib
 
         protected async Task DisplayUsage(string usageString)
         {
-            await CreateEmbed(
+            Helper LocalHelper = new Helper();
+            await LocalHelper.CreateEmbed(
+                Context,
                 Constants.EMOJI_INFORMATION,
                 Constants.USAGE_TITLE,
                 usageString
                 );
-        }
-
-        private static readonly log4net.ILog logger =
-             log4net.LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
-        public async Task DeleteMessage()
-        {
-            logger.Debug("Deleting command message " +
-                Context.Message + " from " + Context.User.Username + " in " + Context.Channel.Name);
-            await Context.Message.DeleteAsync();
-        }
-
-        public async Task CreateEmbed(
-            string emoji = null,
-            string title = null,
-            string content = null,
-            bool removeoriginalmessage = true)
-        {
-
-            var embed = new EmbedBuilder();
-
-            // Add a random color to the embedded post
-            embed.WithColor(Helper.GetRandomColor());
-
-            // Add Title
-            // Add emoji if any
-            if (emoji != null || emoji != String.Empty)
-            {
-                embed.WithTitle(emoji + " " + title);
-            }
-            else
-            {
-                embed.WithTitle(title);
-            }
-
-            // Add content
-            embed.WithDescription(content);
-
-            // Footer
-            // Add invoker
-            embed.WithFooter(footer => footer.Text = string.Format(
-                Constants.INVOKED_BY, Context.User.Username));
-
-            // Add timestamp
-            embed.WithCurrentTimestamp();
-
-            // Remove original if needed
-            if (removeoriginalmessage)
-            {
-                await DeleteMessage();
-            }
-
-            // Send message
-            await ReplyAsync(string.Empty, false, embed);
         }
     }
 }

--- a/DiscordBotLib/BreakingChanges.cs
+++ b/DiscordBotLib/BreakingChanges.cs
@@ -25,7 +25,9 @@ namespace DiscordBotLib
         [Command("breaking_changes")]
         public async Task BreakingChangesAsync([Remainder]string version)
         {
-            var embed = new EmbedBuilder();
+            string emoji = null;
+            string title = null;
+            string body = null;
 
             // get the release notes of the specified version number
             string url = Helper.SitemapLookup("release-" + version);
@@ -33,21 +35,22 @@ namespace DiscordBotLib
 
             if (url == string.Empty)
             {
-                embed.WithTitle(Constants.EMOJI_THUMBSDOWN);
-                embed.WithColor(Helper.GetRandomColor());
-                embed.AddField("Sorry!", "No release changes found for that version!");
-                await ReplyAsync(string.Empty, false, embed);
-                return;
+                emoji = Constants.EMOJI_THUMBSDOWN;
+                title = "Sorry!";
+                body = $"No release changes found for {version}!";
             }
             else
             {
-                if ( url.EndsWith("/"))
+                if (url.EndsWith("/"))
                     url += "#breaking-changes";
                 else
                     url += "/#breaking-changes";
+
+                body = "<" + url + ">";
             }
 
-            await ReplyAsync("<" + url + ">" );
+            // Send response
+            await Helper.CreateEmbed(Context, emoji, title, body, null, true);
         }
     }
 }

--- a/DiscordBotLib/Constants.cs
+++ b/DiscordBotLib/Constants.cs
@@ -96,9 +96,10 @@ namespace DiscordBotLib
                 "You have not subscribed to '{0}'.";
         public static readonly string INFO_UNSUBSCRIBE_SUCCESS =
                 "Successfully unsubscribed to '{0}'.";
-
+        public static readonly string INVOKED_BY =
+                "Invoked by: {0}";
         public static readonly string MAXLINELIMITMESSAGE =
-            "Attention!: Please use <https://www.hastebin.com> to share code that is more than 10-15 lines. You have been warned, {0}!;";
+                "Attention!: Please use <https://www.hastebin.com> to share code that is more than 10-15 lines. You have been warned, {0}!;";
 
         public static readonly string COMMAND_REFRESH_SUCCESSFUL =
                 "Commands, Sitemap and Blocked Domains are reloaded and ready to go!";

--- a/DiscordBotLib/DiscordBot.cs
+++ b/DiscordBotLib/DiscordBot.cs
@@ -179,7 +179,7 @@ namespace DiscordBotLib
             string command = key.Split(' ')[0];
 
             // handle custom command
-            await HandleCustomCommand(command, message, mentionedUsers, result);
+            await HandleCustomCommand(command, message, context, mentionedUsers, result);
         }
 
         private static async Task HandleLineCount(SocketUserMessage message, SocketCommandContext context)
@@ -305,12 +305,15 @@ namespace DiscordBotLib
                 return false;
         }
 
-        private static async Task HandleCustomCommand(string command, SocketUserMessage message, string mentionedUsers, IResult result)
+        private static async Task HandleCustomCommand(string command, SocketUserMessage message, SocketCommandContext context, string mentionedUsers, IResult result)
         {
             string response = HassBotCommands.Instance.Lookup(command);
+            Helper LocalHelper = new Helper();
             if (string.Empty != response)
             {
-                await message.Channel.SendMessageAsync(mentionedUsers + response);
+                await LocalHelper.CreateEmbed(
+                    context, null, null,
+                    string.Format("{0} {1}", mentionedUsers, response));
             }
             else
             {
@@ -321,7 +324,9 @@ namespace DiscordBotLib
                 string lookupResult = Sitemap.Lookup(command);
                 if (string.Empty != lookupResult)
                 {
-                    await message.Channel.SendMessageAsync(mentionedUsers + lookupResult);
+                    await LocalHelper.CreateEmbed(
+                        context, null, null,
+                        string.Format("{0} {1}", mentionedUsers, lookupResult));
                 }
             }
         }

--- a/DiscordBotLib/DiscordBot.cs
+++ b/DiscordBotLib/DiscordBot.cs
@@ -311,9 +311,11 @@ namespace DiscordBotLib
             Helper LocalHelper = new Helper();
             if (string.Empty != response)
             {
+                logger.Debug(mentionedUsers);
                 await LocalHelper.CreateEmbed(
                     context, null, null,
                     string.Format("{0} {1}", mentionedUsers, response));
+                logger.Debug("got here");
             }
             else
             {
@@ -324,9 +326,11 @@ namespace DiscordBotLib
                 string lookupResult = Sitemap.Lookup(command);
                 if (string.Empty != lookupResult)
                 {
+                    logger.Debug("got here");
                     await LocalHelper.CreateEmbed(
                         context, null, null,
                         string.Format("{0} {1}", mentionedUsers, lookupResult));
+                    logger.Debug("got here");
                 }
             }
         }

--- a/DiscordBotLib/DiscordBot.cs
+++ b/DiscordBotLib/DiscordBot.cs
@@ -308,10 +308,9 @@ namespace DiscordBotLib
         private static async Task HandleCustomCommand(string command, SocketUserMessage message, SocketCommandContext context, string mentionedUsers, IResult result)
         {
             string response = HassBotCommands.Instance.Lookup(command);
-            Helper LocalHelper = new Helper();
             if (string.Empty != response)
             {
-                await LocalHelper.CreateEmbed(
+                await Helper.CreateEmbed(
                     context, null, null,
                     string.Format("{0} {1}", mentionedUsers, response));
             }
@@ -324,7 +323,7 @@ namespace DiscordBotLib
                 string lookupResult = Sitemap.Lookup(command);
                 if (string.Empty != lookupResult)
                 {
-                    await LocalHelper.CreateEmbed(
+                    await Helper.CreateEmbed(
                         context, null, null,
                         string.Format("{0} {1}", mentionedUsers, lookupResult));
                 }

--- a/DiscordBotLib/DiscordBot.cs
+++ b/DiscordBotLib/DiscordBot.cs
@@ -211,7 +211,7 @@ namespace DiscordBotLib
 
                 // publish the URL link
                 string response = string.Format(HASTEBIN_MESSAGE, context.User.Mention, url);
-                await message.Channel.SendMessageAsync(response);
+                await Helper.CreateEmbed(context, null, null, response);
 
                 //// Violation Management
                 //ViolationsManager.TheViolationsManager.AddIncident(context.User.Id, context.User.Username, CommonViolationTypes.Codewall.ToString(), context.Channel.Name);                

--- a/DiscordBotLib/DiscordBot.cs
+++ b/DiscordBotLib/DiscordBot.cs
@@ -311,11 +311,9 @@ namespace DiscordBotLib
             Helper LocalHelper = new Helper();
             if (string.Empty != response)
             {
-                logger.Debug(mentionedUsers);
                 await LocalHelper.CreateEmbed(
                     context, null, null,
                     string.Format("{0} {1}", mentionedUsers, response));
-                logger.Debug("got here");
             }
             else
             {
@@ -326,11 +324,9 @@ namespace DiscordBotLib
                 string lookupResult = Sitemap.Lookup(command);
                 if (string.Empty != lookupResult)
                 {
-                    logger.Debug("got here");
                     await LocalHelper.CreateEmbed(
                         context, null, null,
                         string.Format("{0} {1}", mentionedUsers, lookupResult));
-                    logger.Debug("got here");
                 }
             }
         }

--- a/DiscordBotLib/DiscordBotLib.csproj
+++ b/DiscordBotLib/DiscordBotLib.csproj
@@ -158,7 +158,6 @@
     <Compile Include="YamlModule.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/DiscordBotLib/FormatModule.cs
+++ b/DiscordBotLib/FormatModule.cs
@@ -24,7 +24,6 @@ namespace DiscordBotLib
         }
 
         private async Task FormatCommand() {
-            Helper LocalHelper = new Helper();
             StringBuilder sb = new StringBuilder();
 
             // mention users if any
@@ -40,7 +39,7 @@ namespace DiscordBotLib
             sb.Append("Watch the animated gif here: <https://bit.ly/2GbfRJE>\n");
             sb.Append("**DO NOT** repeat posts. Please edit previously posted message, here is how -> <https://bit.ly/2qOOf1G>");
 
-            await LocalHelper.CreateEmbed(
+            await Helper.CreateEmbed(
                 Context,
                 null, // Emoji to title
                 null, // Title

--- a/DiscordBotLib/FormatModule.cs
+++ b/DiscordBotLib/FormatModule.cs
@@ -24,6 +24,7 @@ namespace DiscordBotLib
         }
 
         private async Task FormatCommand() {
+            Helper LocalHelper = new Helper();
             StringBuilder sb = new StringBuilder();
 
             // mention users if any
@@ -39,7 +40,11 @@ namespace DiscordBotLib
             sb.Append("Watch the animated gif here: <https://bit.ly/2GbfRJE>\n");
             sb.Append("**DO NOT** repeat posts. Please edit previously posted message, here is how -> <https://bit.ly/2qOOf1G>");
 
-            await ReplyAsync(sb.ToString(), false, null);
+            await LocalHelper.CreateEmbed(
+                Context,
+                null, // Emoji to title
+                null, // Title
+                sb.ToString()); // Content of the message
         }
     }
 }

--- a/DiscordBotLib/Helper.cs
+++ b/DiscordBotLib/Helper.cs
@@ -492,15 +492,10 @@ namespace DiscordBotLib
             embed.WithCurrentTimestamp();
 
             // Remove original if needed
-            logger.Debug("Deleting");
             await DeleteMessage(context, forceremoveoriginalmessage);
-            logger.Debug("Deleted");
 
             // Send message
-            logger.Debug("Sending");
             await context.Channel.SendMessageAsync(string.Empty, false, embed);
-            logger.Debug("Sendt");
-            //return null;
         }
     }
 }

--- a/DiscordBotLib/Helper.cs
+++ b/DiscordBotLib/Helper.cs
@@ -420,7 +420,7 @@ namespace DiscordBotLib
             return true;
         }
 
-        public async Task DeleteMessage(SocketCommandContext context, bool forceremoveoriginalmessage)
+        public static async Task DeleteMessage(SocketCommandContext context, bool forceremoveoriginalmessage)
         {
             if (forceremoveoriginalmessage)
             {
@@ -456,7 +456,7 @@ namespace DiscordBotLib
 
         }
 
-        public async Task CreateEmbed(
+        public static async Task CreateEmbed(
             SocketCommandContext context,
             string emoji = null,
             string title = null,

--- a/DiscordBotLib/Helper.cs
+++ b/DiscordBotLib/Helper.cs
@@ -461,6 +461,7 @@ namespace DiscordBotLib
             string emoji = null,
             string title = null,
             string content = null,
+            List<Tuple<string, string>> inline = null,
             bool forceremoveoriginalmessage = false)
         {
 
@@ -482,6 +483,13 @@ namespace DiscordBotLib
 
             // Add content
             embed.WithDescription(content);
+            if (inline != null)
+            {
+                foreach (Tuple<string, string> inlineitem in inline)
+                {
+                    embed.AddInlineField(inlineitem.Item1, inlineitem.Item2);
+                }
+            }
 
             // Footer
             // Add invoker

--- a/DiscordBotLib/Helper.cs
+++ b/DiscordBotLib/Helper.cs
@@ -242,7 +242,7 @@ namespace DiscordBotLib
         public static async Task VerifyUrls(string content, SocketCommandContext context)
         {
             Regex re = new Regex(@"((http|ftp|https):\/\/[\w\-_]+(\.[\w\-_]+)+([\w\-\.,@?^=%&amp;:/~\+#]*[\w\-\@?^=%&amp;/~\+#])?)");
-            
+
         }
 
         public static async Task CheckBlockedDomains(string content, SocketCommandContext context)
@@ -252,7 +252,7 @@ namespace DiscordBotLib
             {
                 if (content.Contains(domain.Url))
                 {
-                    if (domain.Ban == true )
+                    if (domain.Ban == true)
                     {
                         // exclude Mods from the bans
                         if (IsMod(context.User))
@@ -263,7 +263,7 @@ namespace DiscordBotLib
                         await context.Guild.AddBanAsync(context.User, 1, reason, null);
 
                         // post a message in the channel about the permanent ban
-                        await context.Message.Channel.SendMessageAsync("BAM!!! " + reason );
+                        await context.Message.Channel.SendMessageAsync("BAM!!! " + reason);
 
                         // send a message to #botspam channel as well
                         string detailedMessage = "Woohoo! " + reason + " Posted message: " + content;
@@ -418,6 +418,59 @@ namespace DiscordBotLib
                 return false;
             }
             return true;
+        }
+
+        public async Task DeleteMessage(SocketCommandContext context)
+        {
+            logger.Debug("Deleting command message " +
+                context.Message + " from " + context.User.Username + " in " + context.Channel.Name);
+            await context.Message.DeleteAsync();
+        }
+
+        public async Task<string> CreateEmbed(
+            SocketCommandContext context,
+            string emoji = null,
+            string title = null,
+            string content = null,
+            bool removeoriginalmessage = true)
+        {
+
+            var embed = new EmbedBuilder();
+
+            // Add a random color to the embedded post
+            embed.WithColor(Helper.GetRandomColor());
+
+            // Add Title
+            // Add emoji if any
+            if (emoji != null || emoji != String.Empty)
+            {
+                embed.WithTitle(emoji + " " + title);
+            }
+            else
+            {
+                embed.WithTitle(title);
+            }
+
+            // Add content
+            embed.WithDescription(content);
+
+            // Footer
+            // Add invoker
+            embed.WithFooter(footer => footer.Text = string.Format(
+                Constants.INVOKED_BY, context.User.Username));
+
+            // Add timestamp
+            embed.WithCurrentTimestamp();
+
+            // Remove original if needed
+            if (removeoriginalmessage)
+            {
+                await DeleteMessage(context);
+            }
+
+            // Send message
+            await context.Channel.SendMessageAsync(string.Empty, false, embed);
+            return null;
         }
     }
 }

--- a/DiscordBotLib/LMGTFY.cs
+++ b/DiscordBotLib/LMGTFY.cs
@@ -42,9 +42,12 @@ namespace DiscordBotLib
             message.Append($"<http://lmgtfy.com/?q={encoded}>");
 
 
-            await base.CreateEmbed(Constants.EMOJI_POINT_UP, // Emoji to title
-                                   Constants.LET_ME_GOOGLE, // Title
-                                   message.ToString()); // Content of the message
+            Helper LocalHelper = new Helper();
+            await LocalHelper.CreateEmbed(
+                Context,
+                Constants.EMOJI_POINT_UP, // Emoji to title
+                Constants.LET_ME_GOOGLE, // Title
+                message.ToString()); // Content of the message
         }
     }
 }

--- a/DiscordBotLib/LMGTFY.cs
+++ b/DiscordBotLib/LMGTFY.cs
@@ -47,7 +47,8 @@ namespace DiscordBotLib
                 Context,
                 Constants.EMOJI_POINT_UP, // Emoji to title
                 Constants.LET_ME_GOOGLE, // Title
-                message.ToString()); // Content of the message
+                message.ToString(), // Content of the message
+                true); // Force delete the message
         }
     }
 }

--- a/DiscordBotLib/LMGTFY.cs
+++ b/DiscordBotLib/LMGTFY.cs
@@ -22,6 +22,10 @@ namespace DiscordBotLib
         [Command("lmgtfy")]
         public async Task LetMeGoogleThatForYouAsync([Remainder]string cmd) {
 
+            string emoji = Constants.EMOJI_POINT_UP;
+            string title = Constants.LET_ME_GOOGLE;
+            string body = null;
+
             // mention users if any
             string mentionedUsers = base.MentionedUsers();
             if (string.Empty != mentionedUsers) {
@@ -31,23 +35,17 @@ namespace DiscordBotLib
                         cmd = cmd.Replace(userHandle.Trim(), string.Empty);
                     }
             }
-            StringBuilder message = new StringBuilder();
-
+            
             // Make sure the generated URL is correct.
             string encoded = HttpUtility.UrlEncode(cmd.Trim());
 
             // Create the message
-            message.Append($"Here {mentionedUsers}, try this:");
-            message.Append("\n"); // New line
-            message.Append($"<http://lmgtfy.com/?q={encoded}>");
+            body = $"Here {mentionedUsers}, try this:";
+            body += "\n"; // New line
+            body += $"<http://lmgtfy.com/?q={encoded}>";
 
-
-            await Helper.CreateEmbed(
-                Context,
-                Constants.EMOJI_POINT_UP, // Emoji to title
-                Constants.LET_ME_GOOGLE, // Title
-                message.ToString(), // Content of the message
-                true); // Force delete the message
+            // Send response
+            await Helper.CreateEmbed(Context, emoji, title, body, null, true);
         }
     }
 }

--- a/DiscordBotLib/LMGTFY.cs
+++ b/DiscordBotLib/LMGTFY.cs
@@ -42,8 +42,7 @@ namespace DiscordBotLib
             message.Append($"<http://lmgtfy.com/?q={encoded}>");
 
 
-            Helper LocalHelper = new Helper();
-            await LocalHelper.CreateEmbed(
+            await Helper.CreateEmbed(
                 Context,
                 Constants.EMOJI_POINT_UP, // Emoji to title
                 Constants.LET_ME_GOOGLE, // Title

--- a/DiscordBotLib/LMGTFY.cs
+++ b/DiscordBotLib/LMGTFY.cs
@@ -4,8 +4,8 @@
 //  FILE            : HassBot.cs
 //  DESCRIPTION     : A class that implements ~lmgtfy command
 ///////////////////////////////////////////////////////////////////////////////
-using Discord;
 using Discord.Commands;
+using System.Text;
 using System.Threading.Tasks;
 using System.Web;
 
@@ -21,9 +21,6 @@ namespace DiscordBotLib
 
         [Command("lmgtfy")]
         public async Task LetMeGoogleThatForYouAsync([Remainder]string cmd) {
-            var embed = new EmbedBuilder();
-            embed.WithTitle(Constants.EMOJI_POINT_UP);
-            embed.WithColor(Helper.GetRandomColor());
 
             // mention users if any
             string mentionedUsers = base.MentionedUsers();
@@ -34,11 +31,20 @@ namespace DiscordBotLib
                         cmd = cmd.Replace(userHandle.Trim(), string.Empty);
                     }
             }
+            StringBuilder message = new StringBuilder();
 
+            // Make sure the generated URL is correct.
             string encoded = HttpUtility.UrlEncode(cmd.Trim());
-            embed.AddInlineField(Constants.LET_ME_GOOGLE,
-                string.Format("Here, try this {0} => <http://lmgtfy.com/?q={1}>", mentionedUsers, encoded));
-            await ReplyAsync(string.Empty, false, embed);
+
+            // Create the message
+            message.Append($"Here {mentionedUsers}, try this:");
+            message.Append("\n"); // New line
+            message.Append($"<http://lmgtfy.com/?q={encoded}>");
+
+
+            await base.CreateEmbed(Constants.EMOJI_POINT_UP, // Emoji to title
+                                   Constants.LET_ME_GOOGLE, // Title
+                                   message.ToString()); // Content of the message
         }
     }
 }

--- a/DiscordBotLib/LookupModule.cs
+++ b/DiscordBotLib/LookupModule.cs
@@ -35,6 +35,12 @@ namespace DiscordBotLib
         }
 
         private async Task LookupCommand(string input) {
+            Helper LocalHelper = new Helper();
+
+            string emoji = String.Empty;
+            string title = String.Empty;
+            string msg = String.Empty;
+
             string result = Helper.SitemapLookup(input);
             result = result.Trim();
 
@@ -43,16 +49,16 @@ namespace DiscordBotLib
 
             var embed = new EmbedBuilder();
             if (result == string.Empty) {
-                embed.WithTitle(string.Format("Searched for '{0}': ", input));
-                embed.WithColor(Helper.GetRandomColor());
-                string msg = string.Format("You may try `~deepsearch {0}`.", input);
-                embed.AddInlineField("Couldn't find it! :frowning:", msg);
+                emoji = ":frowning:";
+                title = string.Format("Searched for '{0}': ", input);
+                msg = string.Format("Couldn't find it!\n\nYou may try `~deepsearch {0}`.", input);
             }
             else {
-                embed.WithColor(Helper.GetRandomColor());
-                embed.AddInlineField("Here is what I found: :smile:", mentionedUsers + result);
+                emoji = ":smile:";
+                title = "Here is what I found:";
+                msg = result;
             }
-            await ReplyAsync(string.Empty, false, embed);
+            await LocalHelper.CreateEmbed(Context, emoji, title, msg, true);
         }
 
         [Command("deepsearch")]

--- a/DiscordBotLib/LookupModule.cs
+++ b/DiscordBotLib/LookupModule.cs
@@ -57,7 +57,7 @@ namespace DiscordBotLib
                 title = "Here is what I found:";
                 msg = result;
             }
-            await Helper.CreateEmbed(Context, emoji, title, msg, true);
+            await Helper.CreateEmbed(Context, emoji, title, msg, null, true);
         }
 
         [Command("deepsearch")]

--- a/DiscordBotLib/LookupModule.cs
+++ b/DiscordBotLib/LookupModule.cs
@@ -35,7 +35,6 @@ namespace DiscordBotLib
         }
 
         private async Task LookupCommand(string input) {
-            Helper LocalHelper = new Helper();
 
             string emoji = String.Empty;
             string title = String.Empty;
@@ -58,7 +57,7 @@ namespace DiscordBotLib
                 title = "Here is what I found:";
                 msg = result;
             }
-            await LocalHelper.CreateEmbed(Context, emoji, title, msg, true);
+            await Helper.CreateEmbed(Context, emoji, title, msg, true);
         }
 
         [Command("deepsearch")]

--- a/DiscordBotLib/PingModule.cs
+++ b/DiscordBotLib/PingModule.cs
@@ -15,7 +15,6 @@ namespace DiscordBotLib
 
         [Command("ping"), Alias("pong")]
         public async Task PingAsync() {
-            Helper LocalHelper = new Helper();
             string response = string.Empty;
             string request = Context.Message.Content.ToLower();
             request = request.Replace("~", string.Empty).Replace(".", string.Empty);
@@ -27,7 +26,7 @@ namespace DiscordBotLib
             if (string.Empty == response)
                 return;
 
-            await LocalHelper.CreateEmbed(
+            await Helper.CreateEmbed(
                 Context,
                 Constants.EMOJI_PING_PONG, // Emoji to title
                 request + "?", // Title

--- a/DiscordBotLib/PingModule.cs
+++ b/DiscordBotLib/PingModule.cs
@@ -15,6 +15,7 @@ namespace DiscordBotLib
 
         [Command("ping"), Alias("pong")]
         public async Task PingAsync() {
+            Helper LocalHelper = new Helper();
             string response = string.Empty;
             string request = Context.Message.Content.ToLower();
             request = request.Replace("~", string.Empty).Replace(".", string.Empty);
@@ -26,11 +27,11 @@ namespace DiscordBotLib
             if (string.Empty == response)
                 return;
 
-            var embed = new EmbedBuilder();
-            embed.WithTitle(Constants.EMOJI_PING_PONG);
-            embed.WithColor(Color.DarkRed);
-            embed.AddField(request + "?", response);
-            await ReplyAsync(string.Empty, false, embed);
+            await LocalHelper.CreateEmbed(
+                Context,
+                Constants.EMOJI_PING_PONG, // Emoji to title
+                request + "?", // Title
+                response); // Content of the message
         }
     }
 }

--- a/DiscordBotLib/VersionModule.cs
+++ b/DiscordBotLib/VersionModule.cs
@@ -67,9 +67,7 @@ namespace DiscordBotLib
             string mentionedUsers = base.MentionedUsers();
             if (string.Empty != mentionedUsers)
                 embed.AddInlineField("FYI", mentionedUsers);
-
-            Helper LocalHelper = new Helper();
-            await LocalHelper.DeleteMessage(Context, true);
+            await Helper.DeleteMessage(Context, true);
             await ReplyAsync(string.Empty, false, embed);
         }
 
@@ -101,8 +99,7 @@ namespace DiscordBotLib
             if (string.Empty != mentionedUsers)
                 embed.AddInlineField("FYI", mentionedUsers);
 
-            Helper LocalHelper = new Helper();
-            await LocalHelper.DeleteMessage(Context, true);
+            await Helper.DeleteMessage(Context, true);
             await ReplyAsync(string.Empty, false, embed);
         }
 

--- a/DiscordBotLib/VersionModule.cs
+++ b/DiscordBotLib/VersionModule.cs
@@ -80,15 +80,15 @@ namespace DiscordBotLib
             var inline = new List<Tuple<string, string>>();
 
             if (null != stable) {
-                inline.Add(new Tuple<string, string>("Stable", stable.HassOS));
-                inline.Add(new Tuple<string, string>("Stable Supervisor", stable.Supervisor));
+                inline.Add(new Tuple<string, string>("Stable Supervisor", stable.HassOS));
+                inline.Add(new Tuple<string, string>("Stable HassOS", stable.Supervisor));
                 inline.Add(new Tuple<string, string>("Stable Home Assistant", stable.HomeAssistant));
             }
 
             if (null != beta) {
-                inline.Add(new Tuple<string, string>("Stable", beta.HassOS));
-                inline.Add(new Tuple<string, string>("Stable Supervisor", beta.Supervisor));
-                inline.Add(new Tuple<string, string>("Stable Home Assistant", beta.HomeAssistant));
+                inline.Add(new Tuple<string, string>("Beta Supervisor", beta.HassOS));
+                inline.Add(new Tuple<string, string>("Beta HassOS", beta.Supervisor));
+                inline.Add(new Tuple<string, string>("Beta Home Assistant", beta.HomeAssistant));
             }
 
             // mention users if any
@@ -140,7 +140,7 @@ namespace DiscordBotLib
                     }
                 }
                 foreach (dynamic item in entries) {
-                    if (item.prerelease == true && item.draft == false) {
+                    if (item.draft == false) {
                         ha.Beta = item.name;
                         break;
                     }

--- a/DiscordBotLib/VersionModule.cs
+++ b/DiscordBotLib/VersionModule.cs
@@ -58,6 +58,9 @@ namespace DiscordBotLib
                 // embed.AddInlineField("As of", DateTime.Now.ToShortDateString());
                 embed.AddInlineField("Stable", ha.Stable);
                 embed.AddInlineField("Beta", ha.Beta);
+                embed.WithCurrentTimestamp();
+                embed.WithFooter(footer => footer.Text = string.Format(
+                    Constants.INVOKED_BY, Context.User.Username));
             }
 
             // mention users if any
@@ -65,6 +68,8 @@ namespace DiscordBotLib
             if (string.Empty != mentionedUsers)
                 embed.AddInlineField("FYI", mentionedUsers);
 
+            Helper LocalHelper = new Helper();
+            await LocalHelper.DeleteMessage(Context, true);
             await ReplyAsync(string.Empty, false, embed);
         }
 
@@ -75,6 +80,9 @@ namespace DiscordBotLib
             var embed = new EmbedBuilder();
             embed.WithTitle("Here are the current HASSIO software versions.\n");
             embed.WithColor(Helper.GetRandomColor());
+            embed.WithCurrentTimestamp();
+            embed.WithFooter(footer => footer.Text = string.Format(
+                    Constants.INVOKED_BY, Context.User.Username));
 
             if (null != stable) {
                 embed.AddInlineField("Stable", stable.HassOS);
@@ -93,6 +101,8 @@ namespace DiscordBotLib
             if (string.Empty != mentionedUsers)
                 embed.AddInlineField("FYI", mentionedUsers);
 
+            Helper LocalHelper = new Helper();
+            await LocalHelper.DeleteMessage(Context, true);
             await ReplyAsync(string.Empty, false, embed);
         }
 

--- a/DiscordBotLib/VersionModule.cs
+++ b/DiscordBotLib/VersionModule.cs
@@ -13,6 +13,7 @@ using Discord;
 using HassBotDTOs;
 using Newtonsoft.Json;
 using System.Reflection;
+using System.Collections.Generic;
 
 namespace DiscordBotLib
 {
@@ -50,57 +51,53 @@ namespace DiscordBotLib
         private async Task GetHAVersion() {
             HomeAssistantVersion ha = GetHAVersions();
 
-            var embed = new EmbedBuilder();
-            embed.WithTitle("Here are the current Home Assistant software versions.\n");
-            embed.WithColor(Helper.GetRandomColor());
+            string emoji = ":hass:";
+            string title = "Here are the current Home Assistant software versions.";
+            string body = null;
+            var inline = new List<Tuple<string, string>>();
 
             if (null != ha) {
-                // embed.AddInlineField("As of", DateTime.Now.ToShortDateString());
-                embed.AddInlineField("Stable", ha.Stable);
-                embed.AddInlineField("Beta", ha.Beta);
-                embed.WithCurrentTimestamp();
-                embed.WithFooter(footer => footer.Text = string.Format(
-                    Constants.INVOKED_BY, Context.User.Username));
+                inline.Add(new Tuple<string, string>("Stable", ha.Stable));
+                inline.Add(new Tuple<string, string>("Beta", ha.Beta));
             }
 
             // mention users if any
             string mentionedUsers = base.MentionedUsers();
             if (string.Empty != mentionedUsers)
-                embed.AddInlineField("FYI", mentionedUsers);
-            await Helper.DeleteMessage(Context, true);
-            await ReplyAsync(string.Empty, false, embed);
+                body = string.Format("FYI {0} \n", mentionedUsers) + body;
+
+            // Send response
+            await Helper.CreateEmbed(Context, emoji, title, body, inline, true);
         }
 
         private async Task GetHASSIOVersion() {
             HassIOVersion beta = GetHassIOVersion(HassioRelease.Beta);
             HassIOVersion stable = GetHassIOVersion(HassioRelease.Stable);
 
-            var embed = new EmbedBuilder();
-            embed.WithTitle("Here are the current HASSIO software versions.\n");
-            embed.WithColor(Helper.GetRandomColor());
-            embed.WithCurrentTimestamp();
-            embed.WithFooter(footer => footer.Text = string.Format(
-                    Constants.INVOKED_BY, Context.User.Username));
+            string emoji = ":hass:";
+            string title = "Here are the current HASSIO software versions.";
+            string body = null;
+            var inline = new List<Tuple<string, string>>();
 
             if (null != stable) {
-                embed.AddInlineField("Stable", stable.HassOS);
-                embed.AddInlineField("Stable Supervisor", stable.Supervisor);
-                embed.AddInlineField("Stable Home Assistant", stable.HomeAssistant);
+                inline.Add(new Tuple<string, string>("Stable", stable.HassOS));
+                inline.Add(new Tuple<string, string>("Stable Supervisor", stable.Supervisor));
+                inline.Add(new Tuple<string, string>("Stable Home Assistant", stable.HomeAssistant));
             }
 
             if (null != beta) {
-                embed.AddInlineField("Beta", beta.HassOS);
-                embed.AddInlineField("Beta Supervisor", beta.Supervisor);
-                embed.AddInlineField("Beta Home Assistant", beta.HomeAssistant);
+                inline.Add(new Tuple<string, string>("Stable", beta.HassOS));
+                inline.Add(new Tuple<string, string>("Stable Supervisor", beta.Supervisor));
+                inline.Add(new Tuple<string, string>("Stable Home Assistant", beta.HomeAssistant));
             }
 
             // mention users if any
             string mentionedUsers = base.MentionedUsers();
             if (string.Empty != mentionedUsers)
-                embed.AddInlineField("FYI", mentionedUsers);
+                body = string.Format("FYI {0} \n", mentionedUsers) + body;
 
-            await Helper.DeleteMessage(Context, true);
-            await ReplyAsync(string.Empty, false, embed);
+            // Send response
+            await Helper.CreateEmbed(Context, emoji, title, body, inline, true);
         }
 
         public static HassIOVersion GetHassIOVersion(HassioRelease release) {


### PR DESCRIPTION
# Description
*Added two new things to `DiscodBotLib.Helper`*

- DeleteMessage
- CreateEmbed

**The "new" embedder will.**

- Deletes the original message that invoked the command.
  - Messages are only deleted if it only contains the command (and mentions)
  - Unless the [`forceremoveoriginalmessage`](https://github.com/skalavala/HassBot/blob/fd7a08c4c0fe8d314623d43a743b100b25dd0256/DiscordBotLib/Helper.cs#L465) is used, then it always deletes it.
- Format the post (like the previous version)
- Add the invokers name.

Demo: 
![proposal](https://user-images.githubusercontent.com/15093472/56081124-051d4900-5e0a-11e9-95b9-e645488ece34.gif)


### "Converted" modules/functions:

- LMGTFY
- BaseModule.DisplayUsage
- 8ball
- CustomCommands
- Format module
- Ping module
- Lookup module
- Version module
- Breaking changes module
- About module