### PR TITLE
Add "..." exception to YamlValidator

### DIFF
--- a/HassBotUtils/YamlValidator.cs
+++ b/HassBotUtils/YamlValidator.cs
@@ -22,6 +22,7 @@ namespace HassBotUtils
                 yamlData = yamlData.Replace("!include_dir_named ", string.Empty);
                 yamlData = yamlData.Replace("!include_dir_merge_list ", string.Empty);
                 yamlData = yamlData.Replace("!include_dir_merge_named ", string.Empty);
+                yamlData = yamlData.Replace("...", string.Empty);
 
                 errorMessage = string.Empty;
                 var input = new StringReader(yamlData);


### PR DESCRIPTION
Before and after the change:
![image](https://user-images.githubusercontent.com/15093472/58348258-7c5de800-7e60-11e9-9bd8-5b96720de3ac.png)

`...` are used to show that there is something not worth mentioning, and this fails with the current code.