### PR TITLE
changed lmgtfy link

### DIFF
--- a/DiscordBotLib/LMGTFY.cs
+++ b/DiscordBotLib/LMGTFY.cs
@@ -41,7 +41,7 @@ namespace DiscordBotLib
             // Create the message
             body = $"Here {mentionedUsers}, try this:";
             body += "\n"; // New line
-            body += $"<http://lmgtfy.com/?q={encoded}>";
+            body += $"<http://letmegooglethat.com/?q={encoded}>";
 
             // Send response
             await Helper.CreateEmbed(Context, emoji, title, body, null, true);


### PR DESCRIPTION
lmgtfy will no longer redirect to a google search. Even setting `s=g`, which is supposed to switch the search engine to google, does nothing and you still get redirected to a "lmgtfy" search engine. They need to change their name to lmlmgtfytfy.

As a fix we can just use a different site that does the same thing that lmgtfy used to do.
The other option is to link directly to a google search, but what's the fun in that?